### PR TITLE
Fix rollback return result

### DIFF
--- a/flowforge.api/Services/WorkflowRevisionService.cs
+++ b/flowforge.api/Services/WorkflowRevisionService.cs
@@ -49,7 +49,7 @@ public class WorkflowRevisionService : IWorkflowRevisionService
             return false;
 
         workflow.Name = revision.Version;
-        await _workflowRepository.UpdateAsync(workflow);
-        return true;
+        var updated = await _workflowRepository.UpdateAsync(workflow);
+        return updated;
     }
 }

--- a/flowforge.nunit/Services/WorkflowRevisionServiceTests.cs
+++ b/flowforge.nunit/Services/WorkflowRevisionServiceTests.cs
@@ -193,4 +193,22 @@ public class WorkflowRevisionServiceTests
         _workflowRepoMock.Verify(r => r.GetByIdAsync(1), Times.Once);
         _workflowRepoMock.Verify(r => r.UpdateAsync(workflow), Times.Once);
     }
+
+    [Test]
+    public async Task RollbackToRevisionAsync_ReturnsFalse_WhenUpdateFails()
+    {
+        var revision = new WorkflowRevision { Id = 5, WorkflowId = 1, Version = "v2" };
+        var workflow = new Workflow { Id = 1, Name = "old" };
+        _repoMock.Setup(r => r.GetByIdAsync(5)).ReturnsAsync(revision);
+        _workflowRepoMock.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(workflow);
+        _workflowRepoMock.Setup(r => r.UpdateAsync(workflow)).Returns(Task.FromResult(false));
+
+        var result = await _service.RollbackToRevisionAsync(1, 5);
+
+        Assert.That(result, Is.False);
+        Assert.That(workflow.Name, Is.EqualTo("v2"));
+        _repoMock.Verify(r => r.GetByIdAsync(5), Times.Once);
+        _workflowRepoMock.Verify(r => r.GetByIdAsync(1), Times.Once);
+        _workflowRepoMock.Verify(r => r.UpdateAsync(workflow), Times.Once);
+    }
 }


### PR DESCRIPTION
## Summary
- capture the update result in `WorkflowRevisionService`
- add a unit test for failed workflow update

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d61b8f4a48328ad27086744990140