### PR TITLE
Fix SystemBlocks seed comment

### DIFF
--- a/flowforge.api/Data/FlowforgeDbContext.cs
+++ b/flowforge.api/Data/FlowforgeDbContext.cs
@@ -71,7 +71,7 @@ public class FlowforgeDbContext : DbContext
             .HasForeignKey(we => we.WorkflowId)
             .OnDelete(DeleteBehavior.Cascade);
 
-        // Seed danych do SystemBlocks
+        // Seed data for SystemBlocks
         modelBuilder.Entity<SystemBlock>().HasData(
             new SystemBlock { Id = 1, Type = "Start", Description = "Blok początkowy" },
             new SystemBlock { Id = 2, Type = "End", Description = "Blok końcowy" },


### PR DESCRIPTION
## Summary
- fix English translation for seeding SystemBlocks in the DbContext

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d61c371e08328836f622699456d0d