### PR TITLE
Add calculation block support

### DIFF
--- a/flowforge.api/Data/FlowforgeDbContext.cs
+++ b/flowforge.api/Data/FlowforgeDbContext.cs
@@ -75,7 +75,7 @@ public class FlowforgeDbContext : DbContext
         modelBuilder.Entity<SystemBlock>().HasData(
             new SystemBlock { Id = 1, Type = "Start", Description = "Blok początkowy" },
             new SystemBlock { Id = 2, Type = "End", Description = "Blok końcowy" },
-            new SystemBlock { Id = 3, Type = "Add", Description = "Blok dodawania" }
+            new SystemBlock { Id = 3, Type = "Calculation", Description = "Blok kalkulacji" }
         );
     }
 }

--- a/flowforge.api/Migrations/20250531195557_JsonConfiguirationBlock.Designer.cs
+++ b/flowforge.api/Migrations/20250531195557_JsonConfiguirationBlock.Designer.cs
@@ -103,8 +103,8 @@ namespace Flowforge.Migrations
                         new
                         {
                             Id = 3,
-                            Description = "Blok dodawania",
-                            Type = "Add"
+                            Description = "Blok kalkulacji",
+                            Type = "Calculation"
                         });
                 });
 

--- a/flowforge.api/Migrations/20250531195557_JsonConfiguirationBlock.cs
+++ b/flowforge.api/Migrations/20250531195557_JsonConfiguirationBlock.cs
@@ -21,7 +21,7 @@ namespace Flowforge.Migrations
                 keyColumn: "Id",
                 keyValue: 3,
                 columns: new[] { "Description", "Type" },
-                values: new object[] { "Blok dodawania", "Add" });
+                values: new object[] { "Blok kalkulacji", "Calculation" });
         }
 
         /// <inheritdoc />

--- a/flowforge.api/Migrations/20250601121815_JsonConfiguirationBlockFix.Designer.cs
+++ b/flowforge.api/Migrations/20250601121815_JsonConfiguirationBlockFix.Designer.cs
@@ -103,8 +103,8 @@ namespace Flowforge.Migrations
                         new
                         {
                             Id = 3,
-                            Description = "Blok dodawania",
-                            Type = "Add"
+                            Description = "Blok kalkulacji",
+                            Type = "Calculation"
                         });
                 });
 

--- a/flowforge.api/Migrations/FlowforgeDbContextModelSnapshot.cs
+++ b/flowforge.api/Migrations/FlowforgeDbContextModelSnapshot.cs
@@ -100,8 +100,8 @@ namespace Flowforge.Migrations
                         new
                         {
                             Id = 3,
-                            Description = "Blok dodawania",
-                            Type = "Add"
+                            Description = "Blok kalkulacji",
+                            Type = "Calculation"
                         });
                 });
 

--- a/flowforge.api/Models/CalculationConfig.cs
+++ b/flowforge.api/Models/CalculationConfig.cs
@@ -1,0 +1,17 @@
+namespace Flowforge.Models;
+
+public enum CalculationOperation
+{
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Concat
+}
+
+public class CalculationConfig
+{
+    public CalculationOperation Operation { get; set; } = CalculationOperation.Add;
+    public string FirstVariable { get; set; } = string.Empty;
+    public string SecondVariable { get; set; } = string.Empty;
+}

--- a/flowforge.nunit/Models/CalculationConfigTests.cs
+++ b/flowforge.nunit/Models/CalculationConfigTests.cs
@@ -1,0 +1,17 @@
+using Flowforge.Models;
+using NUnit.Framework;
+
+namespace Flowforge.NUnit.Models;
+
+public class CalculationConfigTests
+{
+    [Test]
+    public void Constructor_SetsDefaultValues()
+    {
+        var config = new CalculationConfig();
+
+        Assert.That(config.Operation, Is.EqualTo(CalculationOperation.Add));
+        Assert.That(config.FirstVariable, Is.EqualTo(string.Empty));
+        Assert.That(config.SecondVariable, Is.EqualTo(string.Empty));
+    }
+}


### PR DESCRIPTION
## Summary
- add `CalculationConfig` model for storing block configuration
- seed default `Calculation` system block
- add NUnit tests for the new configuration object
- remove obsolete `Add` system block

## Testing
- `dotnet test flowforge.nunit/Flowforge.NUnit.csproj` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d645df1708328ba60e296b23e7c7f