### PR TITLE
Fix block connection creation

### DIFF
--- a/flowforge.api/Repositories/BlockConnectionRepository.cs
+++ b/flowforge.api/Repositories/BlockConnectionRepository.cs
@@ -34,6 +34,16 @@ public class BlockConnectionRepository : IBlockConnectionRepository
 
     public async Task<BlockConnection> AddAsync(BlockConnection connection)
     {
+        if (connection.SourceBlock != null)
+        {
+            _context.Attach(connection.SourceBlock).State = EntityState.Unchanged;
+        }
+
+        if (connection.TargetBlock != null)
+        {
+            _context.Attach(connection.TargetBlock).State = EntityState.Unchanged;
+        }
+
         _context.BlockConnections.Add(connection);
         await _context.SaveChangesAsync();
         return connection;


### PR DESCRIPTION
## Summary
- ensure EF doesn't try to insert blocks when creating a BlockConnection

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dad0028f083288820073cac295938