### PR TITLE
Support result variable in calculation block

### DIFF
--- a/flowforge.api/Models/CalculationConfig.cs
+++ b/flowforge.api/Models/CalculationConfig.cs
@@ -14,4 +14,5 @@ public class CalculationConfig
     public CalculationOperation Operation { get; set; } = CalculationOperation.Add;
     public string FirstVariable { get; set; } = string.Empty;
     public string SecondVariable { get; set; } = string.Empty;
+    public string ResultVariable { get; set; } = string.Empty;
 }

--- a/flowforge.api/Services/WorkflowExecutionService.cs
+++ b/flowforge.api/Services/WorkflowExecutionService.cs
@@ -56,11 +56,14 @@ public class WorkflowExecutionService : IWorkflowExecutionService
                 {
                     variables.TryGetValue(config.FirstVariable, out var first);
                     variables.TryGetValue(config.SecondVariable, out var second);
+                    var destination = string.IsNullOrEmpty(config.ResultVariable)
+                        ? config.FirstVariable
+                        : config.ResultVariable;
 
                     switch (config.Operation)
                     {
                         case CalculationOperation.Concat:
-                            variables[config.FirstVariable] = (first ?? string.Empty) + (second ?? string.Empty);
+                            variables[destination] = (first ?? string.Empty) + (second ?? string.Empty);
                             break;
                         default:
                             double.TryParse(first, out var a);
@@ -73,7 +76,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
                                 CalculationOperation.Divide => b == 0 ? a : a / b,
                                 _ => a
                             };
-                            variables[config.FirstVariable] = result.ToString();
+                            variables[destination] = result.ToString();
                             break;
                     }
                 }

--- a/flowforge.nunit/Controllers/WorkflowExecutionControllerTests.cs
+++ b/flowforge.nunit/Controllers/WorkflowExecutionControllerTests.cs
@@ -1,6 +1,8 @@
 ﻿using Flowforge.Controllers;
 using Flowforge.Models;
 using Flowforge.Services;
+using Flowforge.Data;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
@@ -12,14 +14,25 @@ namespace Flowforge.NUnit.Controllers;
 [TestFixture]
 public class WorkflowExecutionControllerTests
 {
-    private Mock<IWorkflowExecutionService> _serviceMock;
-    private WorkflowExecutionController _controller;
+    private Flowforge.Data.FlowforgeDbContext _context = null!;
+    private Mock<IWorkflowExecutionService> _serviceMock = null!;
+    private WorkflowExecutionController _controller = null!;
 
     [SetUp]
     public void Setup()
     {
+        var options = new Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<Flowforge.Data.FlowforgeDbContext>()
+            .UseInMemoryDatabase(System.Guid.NewGuid().ToString())
+            .Options;
+        _context = new Flowforge.Data.FlowforgeDbContext(options);
         _serviceMock = new Mock<IWorkflowExecutionService>();
-        _controller = new WorkflowExecutionController(_serviceMock.Object);
+        _controller = new WorkflowExecutionController(_serviceMock.Object, _context);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _context.Dispose();
     }
 
     [Test]

--- a/flowforge.nunit/Flowforge.NUnit.csproj
+++ b/flowforge.nunit/Flowforge.NUnit.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Flowforge.Api\Flowforge.Api.csproj" />    
+        <ProjectReference Include="..\flowforge.api\Flowforge.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/flowforge.nunit/Models/CalculationConfigTests.cs
+++ b/flowforge.nunit/Models/CalculationConfigTests.cs
@@ -13,5 +13,6 @@ public class CalculationConfigTests
         Assert.That(config.Operation, Is.EqualTo(CalculationOperation.Add));
         Assert.That(config.FirstVariable, Is.EqualTo(string.Empty));
         Assert.That(config.SecondVariable, Is.EqualTo(string.Empty));
+        Assert.That(config.ResultVariable, Is.EqualTo(string.Empty));
     }
 }

--- a/flowforge.nunit/Services/WorkflowExecutionEvaluationTests.cs
+++ b/flowforge.nunit/Services/WorkflowExecutionEvaluationTests.cs
@@ -34,7 +34,7 @@ public class WorkflowExecutionEvaluationTests
         _repoMock.Verify(r => r.AddAsync(It.IsAny<WorkflowExecution>()), Times.Once);
         Assert.That(result.ResultData, Is.Not.Null);
         var vars = JsonSerializer.Deserialize<Dictionary<string,string>>(result.ResultData!);
-        Assert.That(vars!["A"], Is.EqualTo("5"));
+        Assert.That(vars!["C"], Is.EqualTo("5"));
     }
 
     private static Workflow BuildWorkflow()
@@ -47,7 +47,7 @@ public class WorkflowExecutionEvaluationTests
 
         var start = new Block { Id = 1, Workflow = workflow, WorkflowId = 1, SystemBlock = startSb, SystemBlockId = 1 };
         var calc = new Block { Id = 2, Workflow = workflow, WorkflowId = 1, SystemBlock = calcSb, SystemBlockId = 3,
-            JsonConfig = JsonSerializer.Serialize(new CalculationConfig { Operation = CalculationOperation.Add, FirstVariable = "A", SecondVariable = "B" }) };
+            JsonConfig = JsonSerializer.Serialize(new CalculationConfig { Operation = CalculationOperation.Add, FirstVariable = "A", SecondVariable = "B", ResultVariable = "C" }) };
         var end = new Block { Id = 3, Workflow = workflow, WorkflowId = 1, SystemBlock = endSb, SystemBlockId = 2 };
 
         start.SourceConnections.Add(new BlockConnection { SourceBlock = start, TargetBlock = calc });
@@ -59,6 +59,7 @@ public class WorkflowExecutionEvaluationTests
 
         workflow.WorkflowVariables.Add(new WorkflowVariable { Id = 1, Name = "A", DefaultValue = "2", Workflow = workflow, WorkflowId = 1, Type = "number" });
         workflow.WorkflowVariables.Add(new WorkflowVariable { Id = 2, Name = "B", DefaultValue = "3", Workflow = workflow, WorkflowId = 1, Type = "number" });
+        workflow.WorkflowVariables.Add(new WorkflowVariable { Id = 3, Name = "C", DefaultValue = "", Workflow = workflow, WorkflowId = 1, Type = "number" });
 
         return workflow;
     }


### PR DESCRIPTION
## Summary
- update `CalculationConfig` to include a `ResultVariable`
- store calculation results in the specified `ResultVariable`
- adjust evaluation logic and tests for the new behaviour
- fix test project path and controller test setup for Linux

## Testing
- `dotnet build Flowforge.sln -v minimal`
- `dotnet test Flowforge.sln --no-build` *(fails: 6 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684db5a65c3c8328ba18874ce9903126