### PR TITLE
Allow input overrides for workflow run

### DIFF
--- a/flowforge.api/Controllers/WorkflowExecutionController.cs
+++ b/flowforge.api/Controllers/WorkflowExecutionController.cs
@@ -68,7 +68,7 @@ public class WorkflowExecutionController : ControllerBase
     }
 
     [HttpPost("/api/Workflow/{id}/run")]
-    public async Task<ActionResult<WorkflowExecution>> Run(int id)
+    public async Task<ActionResult<WorkflowExecution>> Run(int id, [FromBody] Dictionary<string, string>? inputs = null)
     {
         var workflow = await _context.Workflows
             .Include(w => w.Blocks).ThenInclude(b => b.SystemBlock)
@@ -80,7 +80,7 @@ public class WorkflowExecutionController : ControllerBase
         if (workflow == null)
             return NotFound();
 
-        var execution = await _service.EvaluateAsync(workflow);
+        var execution = await _service.EvaluateAsync(workflow, inputs);
 
         return CreatedAtAction(nameof(GetById), new { id = execution.Id }, execution);
     }

--- a/flowforge.api/Services/IWorkflowExecutionService.cs
+++ b/flowforge.api/Services/IWorkflowExecutionService.cs
@@ -11,5 +11,5 @@ public interface IWorkflowExecutionService
     Task<WorkflowExecution> CreateAsync(WorkflowExecution execution);
     Task<bool> UpdateAsync(int id, WorkflowExecution execution);
     Task<bool> DeleteAsync(int id);
-    Task<WorkflowExecution> EvaluateAsync(Workflow workflow);
+    Task<WorkflowExecution> EvaluateAsync(Workflow workflow, Dictionary<string, string>? inputs = null);
 }

--- a/flowforge.nunit/Services/WorkflowExecutionEvaluationTests.cs
+++ b/flowforge.nunit/Services/WorkflowExecutionEvaluationTests.cs
@@ -37,6 +37,23 @@ public class WorkflowExecutionEvaluationTests
         Assert.That(vars!["C"], Is.EqualTo("5"));
     }
 
+    [Test]
+    public async Task EvaluateAsync_UsesInputOverrides()
+    {
+        var workflow = BuildWorkflow();
+        var inputs = new Dictionary<string, string> { ["A"] = "4", ["B"] = "6" };
+
+        var result = await _service.EvaluateAsync(workflow, inputs);
+
+        _repoMock.Verify(r => r.AddAsync(It.IsAny<WorkflowExecution>()), Times.Once);
+        Assert.That(result.InputData, Is.Not.Null);
+        var inputVars = JsonSerializer.Deserialize<Dictionary<string,string>>(result.InputData!);
+        Assert.That(inputVars!["A"], Is.EqualTo("4"));
+
+        var vars = JsonSerializer.Deserialize<Dictionary<string,string>>(result.ResultData!);
+        Assert.That(vars!["C"], Is.EqualTo("10"));
+    }
+
     private static Workflow BuildWorkflow()
     {
         var startSb = new SystemBlock { Id = 1, Type = "Start" };


### PR DESCRIPTION
## Summary
- support sending input variables when running a workflow
- record input data with execution results
- add test verifying input overrides

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5f06bc60832886a6f16e15dced7e