### PR TITLE
Improve workflow execution response readability

### DIFF
--- a/flowforge.api/Controllers/WorkflowExecutionController.cs
+++ b/flowforge.api/Controllers/WorkflowExecutionController.cs
@@ -1,6 +1,7 @@
 ﻿using Flowforge.Models;
 using Flowforge.Services;
 using Flowforge.Data;
+using Flowforge.DTOs;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
@@ -83,6 +84,15 @@ public class WorkflowExecutionController : ControllerBase
 
         var execution = await _service.EvaluateAsync(workflow, inputs);
 
-        return CreatedAtAction(nameof(GetById), new { id = execution.Id }, execution);
+        var dto = new WorkflowExecutionDto
+        {
+            Id = execution.Id,
+            ExecutedAt = execution.ExecutedAt,
+            InputData = execution.Input,
+            ResultData = execution.Result,
+            Path = execution.Path
+        };
+
+        return CreatedAtAction(nameof(GetById), new { id = execution.Id }, dto);
     }
 }

--- a/flowforge.api/DTOs/WorkflowExecutionDto.cs
+++ b/flowforge.api/DTOs/WorkflowExecutionDto.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Flowforge.DTOs;
+
+public class WorkflowExecutionDto
+{
+    public int Id { get; set; }
+    public DateTime ExecutedAt { get; set; }
+
+    [JsonPropertyName("inputData")]
+    public Dictionary<string, string>? InputData { get; set; }
+
+    [JsonPropertyName("resultData")]
+    public Dictionary<string, string>? ResultData { get; set; }
+
+    [JsonPropertyName("path")]
+    public IList<string>? Path { get; set; }
+}

--- a/flowforge.api/Models/WorkflowExecution.cs
+++ b/flowforge.api/Models/WorkflowExecution.cs
@@ -37,4 +37,8 @@ public class WorkflowExecution
 
     public int WorkflowId { get; set; }
     public Workflow Workflow { get; set; } = null!;
+
+    [NotMapped]
+    [JsonPropertyName("path")]
+    public IList<string>? Path { get; set; }
 }


### PR DESCRIPTION
## Summary
- create `WorkflowExecutionDto` for human-friendly output
- track block execution path in the service
- expose the path via `WorkflowExecution` and return a simplified object

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505ea76ed483288e5b6ec804b33624