### PR TITLE
Enable variable syntax for calculation block

### DIFF
--- a/flowforge.api/Models/CalculationConfig.cs
+++ b/flowforge.api/Models/CalculationConfig.cs
@@ -14,7 +14,17 @@ public enum CalculationOperation
 public class CalculationConfig
 {
     public CalculationOperation Operation { get; set; } = CalculationOperation.Add;
-    public string FirstVariable { get; set; } = string.Empty;
-    public string SecondVariable { get; set; } = string.Empty;
-    public string ResultVariable { get; set; } = string.Empty;
+    /// <summary>
+    /// Either a literal value or a variable reference starting with '$'.
+    /// </summary>
+    public string First { get; set; } = string.Empty;
+    /// <summary>
+    /// Either a literal value or a variable reference starting with '$'.
+    /// </summary>
+    public string Second { get; set; } = string.Empty;
+    /// <summary>
+    /// Destination variable name prefixed with '$'. If empty, the first value's
+    /// variable reference will be used when available.
+    /// </summary>
+    public string Result { get; set; } = string.Empty;
 }

--- a/flowforge.nunit/Models/CalculationConfigTests.cs
+++ b/flowforge.nunit/Models/CalculationConfigTests.cs
@@ -11,8 +11,8 @@ public class CalculationConfigTests
         var config = new CalculationConfig();
 
         Assert.That(config.Operation, Is.EqualTo(CalculationOperation.Add));
-        Assert.That(config.FirstVariable, Is.EqualTo(string.Empty));
-        Assert.That(config.SecondVariable, Is.EqualTo(string.Empty));
-        Assert.That(config.ResultVariable, Is.EqualTo(string.Empty));
+        Assert.That(config.First, Is.EqualTo(string.Empty));
+        Assert.That(config.Second, Is.EqualTo(string.Empty));
+        Assert.That(config.Result, Is.EqualTo(string.Empty));
     }
 }

--- a/flowforge.nunit/Services/WorkflowExecutionEvaluationTests.cs
+++ b/flowforge.nunit/Services/WorkflowExecutionEvaluationTests.cs
@@ -143,9 +143,9 @@ public class WorkflowExecutionEvaluationTests
             JsonConfig = JsonSerializer.Serialize(new CalculationConfig
             {
                 Operation = operation,
-                FirstVariable = "A",
-                SecondVariable = "B",
-                ResultVariable = resultVariable ?? string.Empty
+                First = "$A",
+                Second = "$B",
+                Result = string.IsNullOrEmpty(resultVariable) ? string.Empty : "$" + resultVariable
             })
         };
         var end = new Block { Id = 3, Workflow = workflow, WorkflowId = 1, SystemBlock = endSb, SystemBlockId = 2 };


### PR DESCRIPTION
## Summary
- rework `CalculationConfig` to accept `$`-prefixed variables
- update `WorkflowExecutionService` to resolve variables from `$` syntax
- adapt unit tests to new configuration shape

## Testing
- `dotnet test Flowforge.sln -v n` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_686403b3313c8328a53a6a2562aaf1cd